### PR TITLE
Fix upload host validation

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -175,6 +175,11 @@ export const upload = async (
   endpoint.searchParams.append('name', name);
   const fh = await open(path);
   try {
+    const allowedHosts = ['uploads.github.com', 'objects.githubusercontent.com'];
+    if (!allowedHosts.includes(endpoint.hostname)) {
+      throw new Error(`Unknown upload host: ${endpoint.hostname}`);
+    }
+
     const resp = await github.request({
       method: 'POST',
       url: endpoint.toString(),


### PR DESCRIPTION
## Summary
- validate the upload host is a known GitHub domain before making a request

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bc6903208325882e54c922eafcda